### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,17 +12,17 @@ DFR_Key	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-getKey	        KEYWORD2
-setRate         KEYWORD2
+getKey	KEYWORD2
+setRate	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
  
-SAMPLE_WAIT LITERAL1
-NO_KEY LITERAL1
-UP_KEY LITERAL1
-DOWN_KEY LITERAL1
-LEFT_KEY LITERAL1
-RIGHT_KEY LITERAL1
-SELECT_KEY LITERAL1
+SAMPLE_WAIT	LITERAL1
+NO_KEY	LITERAL1
+UP_KEY	LITERAL1
+DOWN_KEY	LITERAL1
+LEFT_KEY	LITERAL1
+RIGHT_KEY	LITERAL1
+SELECT_KEY	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords